### PR TITLE
reject `expandedKey` format, mandate consistency check

### DIFF
--- a/index.html
+++ b/index.html
@@ -1733,6 +1733,23 @@ partial dictionary JsonWebKey {
                       then [= exception/throw =] a
                       {{DataError}}.
                     </p>
+                    <p class=note>
+                      The import operation shall accept `ML-KEM-512-PrivateKey`, `ML-KEM-768-PrivateKey`, or `ML-KEM-1024-PrivateKey`
+                      structures in either the `seed` or `both` CHOICEs.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |mlKemPrivateKey| represents an ML-KEM key in the `expandedKey` format,
+                      [= exception/throw =] a {{NotSupportedError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |mlKemPrivateKey| represents an ML-KEM key in the `both` format,
+                      and the `seed` field does not correspond to the `expandedKey` field,
+                      [= exception/throw =] a {{DataError}}.
+                    </p>
                   </li>
                   <li>
                     <p>
@@ -2889,6 +2906,23 @@ dictionary ContextParams : Algorithm {
                       If an error occurred while parsing,
                       then [= exception/throw =] a
                       {{DataError}}.
+                    </p>
+                    <p class=note>
+                      The import operation shall accept `ML-DSA-44-PrivateKey`, `ML-DSA-65-PrivateKey`, or `ML-DSA-87-PrivateKey`
+                      structures in either the `seed` or `both` CHOICEs.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |mlDsaPrivateKey| represents an ML-DSA key in the `expandedKey` format,
+                      [= exception/throw =] a {{NotSupportedError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |mlDsaPrivateKey| represents an ML-DSA key in the `both` format,
+                      and the `seed` field does not correspond to the `expandedKey` field,
+                      [= exception/throw =] a {{DataError}}.
                     </p>
                   </li>
                   <li>


### PR DESCRIPTION
The import operations should not be limited to seed-only ML-KEM and ML-DSA imports.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-modern-algos/pull/22.html" title="Last updated on Mar 10, 2026, 8:41 AM UTC (32f5bda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/22/ae72ee6...panva:32f5bda.html" title="Last updated on Mar 10, 2026, 8:41 AM UTC (32f5bda)">Diff</a>