### PR TITLE
Throw for KMAC key generation with length=0

### DIFF
--- a/index.html
+++ b/index.html
@@ -6319,9 +6319,17 @@ dictionary KmacParams : Algorithm {
                 |normalizedAlgorithm| is present:
               </dt>
               <dd>
-                Let |length| be equal to the
-                {{KmacKeyGenParams/length}}
-                member of |normalizedAlgorithm|.
+                <ol>
+                  <li>
+                    Let |length| be equal to the
+                    {{KmacKeyGenParams/length}}
+                    member of |normalizedAlgorithm|.
+                  </li>
+                  <li>
+                    If |length| is zero, then [= exception/throw =] an
+                    {{OperationError}}.
+                  </li>
+                </ol>
               </dd>
               <dt>
                 Otherwise, if the {{Algorithm/name}} member of


### PR DESCRIPTION
This is already handled in import with DataError (much like in HMAC), but like with HMAC 0-length generation wasn't rejected with OperationError. This change makes it so.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-modern-algos/pull/24.html" title="Last updated on Sep 11, 2025, 9:12 AM UTC (2c1662b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/24/e9e2771...panva:2c1662b.html" title="Last updated on Sep 11, 2025, 9:12 AM UTC (2c1662b)">Diff</a>