### PR TITLE
Specify how to handle ML-KEM/DSA PKCS8 keys in non-seed-only formats

### DIFF
--- a/index.html
+++ b/index.html
@@ -1730,6 +1730,20 @@ partial dictionary JsonWebKey {
                   </li>
                   <li>
                     <p>
+                      If |mlKemPrivateKey| represents an ML-KEM key in the `expandedKey` format,
+                      or if |mlKemPrivateKey| represents an ML-KEM key in the `both` format
+                      and the `both` format is not supported, throw a {{NotSupportedError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |mlKemPrivateKey| represents an ML-KEM key in the `both` format,
+                      and the `seed` field does not correspond to the `expandedKey` field,
+                      throw a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
                       Let |key| be a new {{CryptoKey}}
                       that represents the ML-KEM private key identified by |mlKemPrivateKey|.
                     </p>
@@ -2892,6 +2906,20 @@ dictionary ContextParams : Algorithm {
                       If an error occurred while parsing,
                       then [= exception/throw =] a
                       {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |mlDsaPrivateKey| represents an ML-DSA key in the `expandedKey` format,
+                      or if |mlDsaPrivateKey| represents an ML-DSA key in the `both` format
+                      and the `both` format is not supported, throw a {{NotSupportedError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |mlDsaPrivateKey| represents an ML-DSA key in the `both` format,
+                      and the `seed` field does not correspond to the `expandedKey` field,
+                      throw a {{DataError}}.
                     </p>
                   </li>
                   <li>


### PR DESCRIPTION
- When importing a key in the `expandedKey` format, throw a `NotSupportedError`.
- When importing a key in the `both` format, *optionally* throw a `NotSupportedError`.
- Alternatively, when importing a key in the `both` format, require checking that the seed and expanded key match.

Address https://github.com/WICG/webcrypto-modern-algos/issues/29.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/pull/34.html" title="Last updated on Nov 13, 2025, 1:24 PM UTC (1ad9116)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/34/8a09cc5...1ad9116.html" title="Last updated on Nov 13, 2025, 1:24 PM UTC (1ad9116)">Diff</a>