### PR TITLE
remove ML-KEM JWK note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1889,9 +1889,6 @@ partial dictionary JsonWebKey {
               <dd>
                 <ol>
                   <li>
-                    <p class="issue">
-                      The JWK format for ML-KEM is not standardized yet and thus subject to change.
-                    </p>
                     <dl class="switch">
                       <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
                       <dd><p>Let |jwk| equal |keyData|.</p></dd>
@@ -2312,9 +2309,6 @@ partial dictionary JsonWebKey {
               <dd>
                 <ol>
                   <li>
-                    <p class="issue">
-                      The JWK format for ML-KEM is not standardized yet and thus subject to change.
-                    </p>
                     <p>
                       Let |jwk| be a new {{JsonWebKey}}
                       dictionary.


### PR DESCRIPTION
https://mailarchive.ietf.org/arch/msg/jose/3roAdYLQ0maMO-0U6oohjHQskhU/ AKP for ML-KEM stays


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-modern-algos/pull/44.html" title="Last updated on Dec 2, 2025, 8:00 AM UTC (935fabc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/44/8a09cc5...panva:935fabc.html" title="Last updated on Dec 2, 2025, 8:00 AM UTC (935fabc)">Diff</a>