### PR TITLE
Set [[type]] in import key operation of AES-OCB

### DIFF
--- a/index.html
+++ b/index.html
@@ -5223,6 +5223,12 @@ dictionary AeadParams : Algorithm {
           </li>
           <li>
             <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| to {{KeyType/"secret"}}.
+            </p>
+          </li>
+          <li>
+            <p>
               Let |algorithm| be a new
               {{AesKeyAlgorithm}}.
             </p>


### PR DESCRIPTION
Setting [[type]] internal slot of key is missing in the import key operation of AES-OCB.

This patch adds the step to set [[type]] internal slot of key to "secret", aligning with the generate key operation of AES-OCB (and the import key oeprations of AES-CTR, AES-CBC, AES-GCM and AES-KW).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kkoyung/webcrypto-modern-algos/pull/49.html" title="Last updated on Feb 3, 2026, 9:15 AM UTC (f4964a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/49/88d3ed8...kkoyung:f4964a6.html" title="Last updated on Feb 3, 2026, 9:15 AM UTC (f4964a6)">Diff</a>