### PR TITLE
Reorder reading algorithm and data arguments

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,14 +546,6 @@ enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits
           </li>
           <li>
             <p>
-              Let |ciphertext| be the result of
-              [= get a copy of the buffer source |
-              getting a copy of the bytes held by =] the `ciphertext` parameter passed to the
-              {{SubtleCrypto/decapsulateKey()}} method.
-            </p>
-          </li>
-          <li>
-            <p>
               Let |normalizedDecapsulationAlgorithm| be the result of
               <a data-cite="webcrypto#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
               `alg` set to |decapsulationAlgorithm| and `op` set to
@@ -578,6 +570,14 @@ enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits
             <p>
               If an error occurred, return a Promise rejected with
               |normalizedSharedKeyAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |ciphertext| be the result of
+              [= get a copy of the buffer source |
+              getting a copy of the bytes held by =] the `ciphertext` parameter passed to the
+              {{SubtleCrypto/decapsulateKey()}} method.
             </p>
           </li>
           <li>
@@ -685,14 +685,6 @@ enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits
           </li>
           <li>
             <p>
-              Let |ciphertext| be the result of
-              [= get a copy of the buffer source |
-              getting a copy of the bytes held by =] the `ciphertext` parameter passed to the
-              {{SubtleCrypto/decapsulateBits()}} method.
-            </p>
-          </li>
-          <li>
-            <p>
               Let |normalizedDecapsulationAlgorithm| be the result of
               <a data-cite="webcrypto#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
               `alg` set to |decapsulationAlgorithm| and `op` set to
@@ -703,6 +695,14 @@ enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits
             <p>
               If an error occurred, return a Promise rejected with
               |normalizedDecapsulationAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |ciphertext| be the result of
+              [= get a copy of the buffer source |
+              getting a copy of the bytes held by =] the `ciphertext` parameter passed to the
+              {{SubtleCrypto/decapsulateBits()}} method.
             </p>
           </li>
           <li>


### PR DESCRIPTION
Read and normalize the algorithm argument(s) before copying the bytes held by data arguments, to enable avoiding the copy if the operation is performed on the same thread (which is currently not possible because the algorithm object getters may modify the data).

To be merged after https://github.com/w3c/webcrypto/pull/426.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/pull/50.html" title="Last updated on Feb 12, 2026, 4:48 PM UTC (a962fd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/50/88d3ed8...a962fd4.html" title="Last updated on Feb 12, 2026, 4:48 PM UTC (a962fd4)">Diff</a>