### PR TITLE
Rename output length params to `outputLength`

### DIFF
--- a/index.html
+++ b/index.html
@@ -6047,12 +6047,12 @@ dictionary AeadParams : Algorithm {
       <h4><dfn data-idl id="dfn-CShakeParams">CShakeParams</dfn> dictionary</h4>
       <pre class=idl>
 dictionary CShakeParams : Algorithm {
-  required [EnforceRange] unsigned long length;
+  required [EnforceRange] unsigned long outputLength;
   BufferSource functionName;
   BufferSource customization;
 };
       </pre>
-      <p>The <dfn data-dfn-for=CShakeParams id=dfn-CShakeParams-length>length</dfn> member represents the requested output length in bits.</p>
+      <p>The <dfn data-dfn-for=CShakeParams id=dfn-CShakeParams-outputLength>outputLength</dfn> member represents the requested output length in bits.</p>
       <p>The <dfn data-dfn-for=CShakeParams id=dfn-CShakeParams-functionName>functionName</dfn> member represents the function name, used by NIST to define functions based on cSHAKE. When used, it should only be set to values defined by NIST.</p>
       <p>The <dfn data-dfn-for=CShakeParams id=dfn-CShakeParams-customization>customization</dfn> member represents the customization string. The application selects this string to define a variant of the function.</p>
     </section>
@@ -6063,7 +6063,7 @@ dictionary CShakeParams : Algorithm {
         <ol>
           <li>
             <p>
-              Let |length| be the {{CShakeParams/length}} member of
+              Let |outputLength| be the {{CShakeParams/outputLength}} member of
               |normalizedAlgorithm|.
             </p>
           </li>
@@ -6092,7 +6092,7 @@ dictionary CShakeParams : Algorithm {
                 Let |result| be the result of performing the cSHAKE128 function
                 defined in Section 3 of [[NIST-SP800-185]] using
                 |message| as the |X| input parameter,
-                |length| as the |L| input parameter,
+                |outputLength| as the |L| input parameter,
                 |functionName| as the |N| input parameter, and
                 |customization| as the |S| input parameter.
               </dd>
@@ -6105,7 +6105,7 @@ dictionary CShakeParams : Algorithm {
                 Let |result| be the result of performing the cSHAKE256 function
                 defined in Section 3 of [[NIST-SP800-185]] using
                 |message| as the |X| input parameter,
-                |length| as the |L| input parameter,
+                |outputLength| as the |L| input parameter,
                 |functionName| as the |N| input parameter, and
                 |customization| as the |S| input parameter.
               </dd>
@@ -6214,11 +6214,11 @@ dictionary KmacKeyAlgorithm : KeyAlgorithm {
       <h4><dfn data-idl id="dfn-KmacParams">KmacParams</dfn> dictionary</h4>
       <pre class=idl>
 dictionary KmacParams : Algorithm {
-  required [EnforceRange] unsigned long length;
+  required [EnforceRange] unsigned long outputLength;
   BufferSource customization;
 };
       </pre>
-      <p>The <dfn data-dfn-for=KmacParams id=dfn-KmacParams-length>length</dfn> member represents the requested output length in bits.</p>
+      <p>The <dfn data-dfn-for=KmacParams id=dfn-KmacParams-outputLength>outputLength</dfn> member represents the requested output length in bits.</p>
       <p>The <dfn data-dfn-for=KmacParams id=dfn-KmacParams-customization>customization</dfn> member represents the customization string. The application selects this string to define a variant of the function.</p>
     </section>
 
@@ -6247,7 +6247,7 @@ dictionary KmacParams : Algorithm {
                 the key represented by <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
                 internal slot of |key| as the |K| input parameter,
                 |message| as the |X| input parameter,
-                the {{KmacParams/length}} member of |normalizedAlgorithm| as
+                the {{KmacParams/outputLength}} member of |normalizedAlgorithm| as
                 the |L| input parameter, and
                 |customization| as
                 the |S| input parameter.
@@ -6263,7 +6263,7 @@ dictionary KmacParams : Algorithm {
                 the key represented by <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
                 internal slot of |key| as the |K| input parameter,
                 |message| as the |X| input parameter,
-                the {{KmacParams/length}} member of |normalizedAlgorithm| as
+                the {{KmacParams/outputLength}} member of |normalizedAlgorithm| as
                 the |L| input parameter, and
                 |customization| as
                 the |S| input parameter.
@@ -6300,7 +6300,7 @@ dictionary KmacParams : Algorithm {
                 the key represented by <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
                 internal slot of |key| as the |K| input parameter,
                 |message| as the |X| input parameter,
-                the {{KmacParams/length}} member of |normalizedAlgorithm| as
+                the {{KmacParams/outputLength}} member of |normalizedAlgorithm| as
                 the |L| input parameter, and
                 |customization| as
                 the |S| input parameter.
@@ -6316,7 +6316,7 @@ dictionary KmacParams : Algorithm {
                 the key represented by <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
                 internal slot of |key| as the |K| input parameter,
                 |message| as the |X| input parameter,
-                the {{KmacParams/length}} member of |normalizedAlgorithm| as
+                the {{KmacParams/outputLength}} member of |normalizedAlgorithm| as
                 the |L| input parameter, and
                 |customization| as
                 the |S| input parameter.


### PR DESCRIPTION
Rename the cSHAKE and KMAC parameters for the output length from `length` to `outputLength`, to avoid confusion with the key length parameters in Web Crypto also named `length`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/pull/52.html" title="Last updated on Feb 15, 2026, 5:16 PM UTC (17c8723)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/52/5dd19e3...17c8723.html" title="Last updated on Feb 15, 2026, 5:16 PM UTC (17c8723)">Diff</a>