### PR TITLE
Allow using KMAC with an empty key

### DIFF
--- a/index.html
+++ b/index.html
@@ -6347,17 +6347,9 @@ dictionary KmacParams : Algorithm {
                 |normalizedAlgorithm| is present:
               </dt>
               <dd>
-                <ol>
-                  <li>
-                    Let |length| be equal to the
-                    {{KmacKeyGenParams/length}}
-                    member of |normalizedAlgorithm|.
-                  </li>
-                  <li>
-                    If |length| is zero, then [= exception/throw =] an
-                    {{OperationError}}.
-                  </li>
-                </ol>
+                Let |length| be equal to the
+                {{KmacKeyGenParams/length}}
+                member of |normalizedAlgorithm|.
               </dd>
               <dt>
                 Otherwise, if the {{Algorithm/name}} member of
@@ -6563,13 +6555,6 @@ dictionary KmacParams : Algorithm {
           <li>
             <p>
               Let |length| be the length in bits of |data|.
-            </p>
-          </li>
-          <li>
-            <p>
-              If |length| is zero
-              then [= exception/throw =] a
-              {{DataError}}.
             </p>
           </li>
           <li>


### PR DESCRIPTION
The requirement that the key length is non-zero was copied from HMAC, but NIST SP 800-185 section 4.2 explicitly says:

> K is a key bit string of any length, including zero.

(with a caveat about the security strength depending on the length of the key, of course).

So, let's match the underlying spec and allow using KMAC with an empty key.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/pull/55.html" title="Last updated on Feb 15, 2026, 8:30 PM UTC (9d48e81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/55/5dd19e3...9d48e81.html" title="Last updated on Feb 15, 2026, 8:30 PM UTC (9d48e81)">Diff</a>