### PR TITLE
Set KmacKeyAlgorithm/length during generateKey

### DIFF
--- a/index.html
+++ b/index.html
@@ -6414,6 +6414,12 @@ dictionary KmacParams : Algorithm {
           </li>
           <li>
             <p>
+              Set the {{KmacKeyAlgorithm/length}} attribute of
+              |algorithm| to |length|.
+            </p>
+          </li>
+          <li>
+            <p>
               Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
               slot of |key| to |algorithm|.
             </p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-modern-algos/pull/57.html" title="Last updated on Mar 10, 2026, 8:21 AM UTC (c2b620b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/57/ae72ee6...panva:c2b620b.html" title="Last updated on Mar 10, 2026, 8:21 AM UTC (c2b620b)">Diff</a>