### PR TITLE
Require KMAC comparison to be constant time

### DIFF
--- a/index.html
+++ b/index.html
@@ -6632,6 +6632,7 @@ dictionary KmacParams : Algorithm {
             <p>
               Return true if |computedMac| is equal to |signature| and false
               otherwise.
+              This comparison must be performed in constant-time.
             </p>
           </li>
         </ol>


### PR DESCRIPTION
See CVE-2026-21713 https://nodejs.org/en/blog/vulnerability/march-2026-security-releases


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-modern-algos/pull/63.html" title="Last updated on Mar 26, 2026, 4:31 PM UTC (c2723af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/63/6543db8...panva:c2723af.html" title="Last updated on Mar 26, 2026, 4:31 PM UTC (c2723af)">Diff</a>