### PR TITLE
Add [EnforceRange] instead of truncating lengths

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@ partial interface SubtleCrypto {
 
   static boolean supports(DOMString operation,
                    AlgorithmIdentifier algorithm,
-                   optional unsigned long? length = null);
+                   optional [EnforceRange] unsigned long? length = null);
   static boolean supports(DOMString operation,
                    AlgorithmIdentifier algorithm,
                    AlgorithmIdentifier additionalAlgorithm);
@@ -6515,7 +6515,7 @@ dictionary KmacImportParams : Algorithm {
       <h4><dfn data-idl id="dfn-KmacKeyAlgorithm">KmacKeyAlgorithm</dfn> dictionary</h4>
       <pre class=idl>
 dictionary KmacKeyAlgorithm : KeyAlgorithm {
-  required unsigned long length;
+  required [EnforceRange] unsigned long length;
 };
       </pre>
       <p>The <dfn data-dfn-for=KmacKeyAlgorithm id=dfn-KmacKeyAlgorithm-length>length</dfn> member represents the length (in bits) of the key.</p>


### PR DESCRIPTION
Refs: https://github.com/w3c/webcrypto/issues/429


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-modern-algos/pull/65.html" title="Last updated on Aug 6, 2026, 5:07 PM UTC (d77b25b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/65/2c82b93...panva:d77b25b.html" title="Last updated on Aug 6, 2026, 5:07 PM UTC (d77b25b)">Diff</a>