### PR TITLE
Define the ECDH length limit for supports("deriveBits")

### DIFF
--- a/index.html
+++ b/index.html
@@ -1121,6 +1121,59 @@ enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits
           </p>
         </li>
         <li>
+          <dl class="switch">
+            <dt>
+              If |op| is "`deriveBits`", the {{Algorithm/name}} member of
+              |normalizedAlgorithm| is a case-sensitive string match for "`ECDH`",
+              and |length| is not null:
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    Let |publicKey| be the {{EcdhKeyDeriveParams/public}}
+                    member of |normalizedAlgorithm|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |publicKeyAlgorithm| be the
+                    <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                    internal slot of |publicKey|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |maximumLength| be the following value, depending on the
+                    {{EcKeyAlgorithm/namedCurve}} attribute of |publicKeyAlgorithm|:
+                  </p>
+                  <dl class="switch">
+                    <dt>If it is "`P-256`":</dt>
+                    <dd>256.</dd>
+                    <dt>If it is "`P-384`":</dt>
+                    <dd>384.</dd>
+                    <dt>If it is "`P-521`":</dt>
+                    <dd>528.</dd>
+                    <dt>Otherwise:</dt>
+                    <dd>Return false.</dd>
+                  </dl>
+                  <p class="note">
+                    This limit matches the length in bits of the byte sequence
+                    returned by the ECDH derive bits operation. For P-521, the
+                    x-coordinate is encoded as 66 octets, so the maximum length
+                    is 528 bits, not 521 bits.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If |length| is greater than |maximumLength|, return false.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+          </dl>
+        </li>
+        <li>
           <p>
             If |op| is "`generateKey`" or "`importKey`", let |usages| be the empty list.
           </p>


### PR DESCRIPTION
SubtleCrypto.supports("deriveBits", algorithm, length) needs an clearer ECDH length rule.

For `P-521`, WebCrypto ECDH returns the x-coordinate. That is 66 bytes (`ceil(521 / 8)`), so `deriveBits(..., 528)` succeeds and returns a 66-byte buffer. `529` should fail.

The spec should say whether `supports("deriveBits", { name: "ECDH", public }, length)` uses that same byte-rounded maximum. Without that, implementations may treat P-521 as capped at 521 bits, even though `deriveBits(..., 528)` is valid.

This PR proposes text, but happy to convert to an issue for discussion


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/thibmeu/webcrypto-modern-algos/pull/74.html" title="Last updated on Jul 10, 2026, 3:44 PM UTC (6a19b78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/74/bc3f28c...thibmeu:6a19b78.html" title="Last updated on Jul 10, 2026, 3:44 PM UTC (6a19b78)">Diff</a>