### PR TITLE
Normalize usage list in generateKey operations

### DIFF
--- a/index.html
+++ b/index.html
@@ -5159,7 +5159,7 @@ dictionary AeadParams : Algorithm {
           <li>
             <p>
               Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
-              |key| to be |usages|.
+              |key| to be the <a data-cite="webcrypto#concept-normalized-usages">normalized value</a> of |usages|.
             </p>
           </li>
           <li>
@@ -5692,7 +5692,7 @@ dictionary AeadParams : Algorithm {
           <li>
             <p>
               Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
-              |key| to be |usages|.
+              |key| to be the <a data-cite="webcrypto#concept-normalized-usages">normalized value</a> of |usages|.
             </p>
           </li>
           <li>
@@ -6728,7 +6728,7 @@ dictionary KmacParams : Algorithm {
           <li>
             <p>
               Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
-              |key| to be |usages|.
+              |key| to be the <a data-cite="webcrypto#concept-normalized-usages">normalized value</a> of |usages|.
             </p>
           </li>
           <li>


### PR DESCRIPTION
Found from the recent changes (https://github.com/web-platform-tests/wpt/pull/61397) in WPT tests.

For the generateKey operations of symmetric key algorithms (AES-OCB, ChaCha20-Poly1305, KMAC), we should normalize the usage list assigned to the [[usages]] internal slot of the new CryptoKey.

Note that, for the generateKey operations of asymmetric key algorithms (ML-KEM, ML-DSA, SLH-DSA), the usage lists assigned to the [[usages]] internal slot of the new CryptoKey are already normalized by the usage intersection
(https://w3c.github.io/webcrypto/#concept-usage-intersection).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kkoyung/webcrypto-modern-algos/pull/75.html" title="Last updated on Aug 6, 2026, 3:36 PM UTC (1f82aa4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/75/bc3f28c...kkoyung:1f82aa4.html" title="Last updated on Aug 6, 2026, 3:36 PM UTC (1f82aa4)">Diff</a>