### PR TITLE
Improve ML-DSA and SLH-DSA steps for the supports() method

### DIFF
--- a/index.html
+++ b/index.html
@@ -2503,6 +2503,13 @@ dictionary ContextParams : Algorithm {
         <ol>
           <li>
             <p>
+              If the {{ContextParams/context}} member of |normalizedAlgorithm|
+              is present and has a [= byte sequence/length =] greater than 255
+              bytes, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
               If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
               |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
             </p>
@@ -2538,6 +2545,13 @@ dictionary ContextParams : Algorithm {
       <section id="ml-dsa-operations-verify">
         <h5>Verify</h5>
         <ol>
+          <li>
+            <p>
+              If the {{ContextParams/context}} member of |normalizedAlgorithm|
+              is present and has a [= byte sequence/length =] greater than 255
+              bytes, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
           <li>
             <p>
               If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of

--- a/index.html
+++ b/index.html
@@ -3666,6 +3666,13 @@ dictionary ContextParams : Algorithm {
         <ol>
           <li>
             <p>
+              If the {{ContextParams/context}} member of |normalizedAlgorithm|
+              is present and has a [= byte sequence/length =] greater than 255
+              bytes, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
               If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
               |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
             </p>


### PR DESCRIPTION
The `SubtleCrypto.supports()` method determines support by executing an operation's steps until it encounters unavailable key or data, key generation, a return, or an exception.

The ML-DSA sign and verify operations and the SLH-DSA sign operation currently reach an unavailable key before the 255-byte context limit can be observed. This makes `supports()` return `true` for a context that cannot be accepted with any key or message.

This PR makes those unconditional failures observable before `supports()` reaches its stopping point. It is the Modern Algorithms counterpart to [w3c/webcrypto#558](https://github.com/w3c/webcrypto/pull/558).

## Changes

- Check the 255-byte context limit before key access in ML-DSA sign and verify operations.
- Check the 255-byte context limit before key access in the SLH-DSA sign operation.
- Leave SLH-DSA verification unchanged because FIPS 205 returns `false`, rather than an error, for an oversized context.

Successful operations are unchanged.

## Examples

Each of the following now returns `false`.

### ML-DSA context

```js
SubtleCrypto.supports("sign", {
  name: "ML-DSA-44",
  context: new Uint8Array(256),
})
```

No ML-DSA key or message can make a 256-byte context valid.

### SLH-DSA signing context

```js
SubtleCrypto.supports("sign", {
  name: "SLH-DSA-SHA2-128s",
  context: new Uint8Array(256),
})
```

No SLH-DSA key or message can make a 256-byte signing context valid. Verification remains unchanged because FIPS 205 returns `false` rather than an error for an oversized context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-modern-algos/pull/76.html" title="Last updated on Aug 7, 2026, 11:28 AM UTC (0c7a4e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/76/597a4f8...panva:0c7a4e8.html" title="Last updated on Aug 7, 2026, 11:28 AM UTC (0c7a4e8)">Diff</a>