### PR TITLE
Add note about the use of XOFs outside `digest()`

### DIFF
--- a/index.html
+++ b/index.html
@@ -6053,6 +6053,12 @@ dictionary AeadParams : Algorithm {
         parameters are empty (or not provided), cSHAKE is functionally equivalent to
         SHAKE as defined in Section 6.2 of [[FIPS-202]].
       </p>
+      <p class="note">
+        Although technically possible to implement, using cSHAKE as part of other algorithms
+        outside {{SubtleCrypto/digest()}} (such as in the {{HmacKeyGenParams/hash}} parameter of HMAC)
+        is unlikely to be useful and not expected to be supported.
+        The result of {{SubtleCrypto/supports()}} should reflect whether such uses are supported.
+      </p>
     </section>
     <section id="cshake-registration">
       <h4>Registration</h4>
@@ -6182,6 +6188,12 @@ dictionary CShakeParams : Algorithm {
         When the output length meets these thresholds, TurboSHAKE128 achieves NIST post-quantum
         security level 2, and TurboSHAKE256 achieves level 5.
         See Section 7 of [[RFC9861]].
+      </p>
+      <p class="note">
+        Although technically possible to implement, using TurboSHAKE as part of other algorithms
+        outside {{SubtleCrypto/digest()}} (such as in the {{HmacKeyGenParams/hash}} parameter of HMAC)
+        is unlikely to be useful and not expected to be supported.
+        The result of {{SubtleCrypto/supports()}} should reflect whether such uses are supported.
       </p>
     </section>
     <section id="turboshake-registration">
@@ -6316,6 +6328,12 @@ dictionary TurboShakeParams : Algorithm {
         When the output length meets these thresholds, KT128 achieves NIST post-quantum
         security level 2, and KT256 achieves level 5.
         See Section 7 of [[RFC9861]].
+      </p>
+      <p class="note">
+        Although technically possible to implement, using KangarooTwelve as part of other algorithms
+        outside {{SubtleCrypto/digest()}} (such as in the {{HmacKeyGenParams/hash}} parameter of HMAC)
+        is unlikely to be useful and not expected to be supported.
+        The result of {{SubtleCrypto/supports()}} should reflect whether such uses are supported.
       </p>
     </section>
     <section id="kangarootwelve-registration">


### PR DESCRIPTION
Note that using extensible output functions (XOFs) as part of other algorithms (outside `SubtleCrypto.digest()`) is unlikely to be useful and not expected to be supported, but that `SubtleCrypto.supports()` should be able to be used to detect whether such uses are supported.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/pull/78.html" title="Last updated on Aug 11, 2026, 11:45 AM UTC (ac10815)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/78/597a4f8...ac10815.html" title="Last updated on Aug 11, 2026, 11:45 AM UTC (ac10815)">Diff</a>